### PR TITLE
fix build break with icpx 2022.1.0

### DIFF
--- a/ksw2_extd2_avx.c
+++ b/ksw2_extd2_avx.c
@@ -93,7 +93,7 @@ void ksw_extd2_avx512(void *km, int qlen, const uint8_t *query, int tlen,
     
     __m512i shf512a, shf512b, slli512;
     __m512i ind512_slli = _mm512_load_si512((__m512i*) index);
-    __mmask8 mska = 0x90;
+    const __mmask8 mska = 0x90;
     __mmask64 mskb = 0x0001000100010000;
     __mmask64 mskc = 0x1;
     __mmask64 mskc_ar[4] = {0x1, 0x10000, 0x100000000, 0x1000000000000};
@@ -933,7 +933,7 @@ void ksw_extd2_avx512_v1(void *km, int qlen, const uint8_t *query, int tlen, con
     
     __m512i shf512a, shf512b, slli512;
     __m512i ind512_slli = _mm512_load_si512((__m512i*) index);
-    __mmask8 mska = 0x90;
+    const __mmask8 mska = 0x90;
     __mmask64 mskb = 0x0001000100010000;
     __mmask64 mskc = 0x1;
     __mmask64 mskc_ar[4] = {0x1, 0x10000, 0x100000000, 0x1000000000000};


### PR DESCRIPTION
```
$ icpx --version
Intel(R) oneAPI DPC++/C++ Compiler 2022.1.0 (2022.1.0.20220316)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/intel/oneapi/compiler/2022.1.0/linux/bin-llvm
```

```
icpx -c -g -Wall -O3 -Wc++-compat  -DHAVE_KALLOC  -DPARALLEL_CHAINING -DALIGN_AVX -DAPPLY_AVX2  -xCORE-AVX512 -I./ext/TAL/src/LISA-hash -I./ext/TAL/src/dynamic-programming  ksw2_extd2_avx.c -o ksw2_extd2_avx.o
ksw2_extd2_avx.c:376:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl_512_mm2_fast;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:43:19: note: expanded from macro '__dp_code_block1_pcl_512_mm2_fast'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:376:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl_512_mm2_fast;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:52:19: note: expanded from macro '__dp_code_block1_pcl_512_mm2_fast'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:376:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl_512_mm2_fast;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:64:19: note: expanded from macro '__dp_code_block1_pcl_512_mm2_fast'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:449:3: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl_512_mm2_fast;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:43:19: note: expanded from macro '__dp_code_block1_pcl_512_mm2_fast'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:449:3: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl_512_mm2_fast;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:52:19: note: expanded from macro '__dp_code_block1_pcl_512_mm2_fast'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:449:3: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl_512_mm2_fast;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:64:19: note: expanded from macro '__dp_code_block1_pcl_512_mm2_fast'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:490:3: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl_512_mm2_fast;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:43:19: note: expanded from macro '__dp_code_block1_pcl_512_mm2_fast'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:490:3: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl_512_mm2_fast;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:52:19: note: expanded from macro '__dp_code_block1_pcl_512_mm2_fast'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:490:3: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl_512_mm2_fast;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:64:19: note: expanded from macro '__dp_code_block1_pcl_512_mm2_fast'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:654:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl_512_mm2_fast;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:43:19: note: expanded from macro '__dp_code_block1_pcl_512_mm2_fast'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:654:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl_512_mm2_fast;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:52:19: note: expanded from macro '__dp_code_block1_pcl_512_mm2_fast'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:654:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl_512_mm2_fast;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:64:19: note: expanded from macro '__dp_code_block1_pcl_512_mm2_fast'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:768:33: warning: unused variable 'tmp' [-Wunused-variable]
                    __m512i H1, tmp, t_;
                                ^
ksw2_extd2_avx.c:1150:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl;
                ^~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:953:19: note: expanded from macro '__dp_code_block1_pcl'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:1150:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl;
                ^~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:962:19: note: expanded from macro '__dp_code_block1_pcl'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:1150:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl;
                ^~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:974:19: note: expanded from macro '__dp_code_block1_pcl'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:1215:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl;
                ^~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:953:19: note: expanded from macro '__dp_code_block1_pcl'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:1215:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl;
                ^~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:962:19: note: expanded from macro '__dp_code_block1_pcl'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:1215:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl;
                ^~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:974:19: note: expanded from macro '__dp_code_block1_pcl'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
ksw2_extd2_avx.c:1252:17: error: argument to '__builtin_ia32_shuf_i32x4' must be a constant integer
                __dp_code_block1_pcl;
                ^~~~~~~~~~~~~~~~~~~~
ksw2_extd2_avx.c:953:19: note: expanded from macro '__dp_code_block1_pcl'
        shf512b = _mm512_shuffle_i32x4(shf512a, shf512a, mska);         \
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2022.1.0/linux/lib/clang/14.0.0/include/avx512fintrin.h:6682:13: note: expanded from macro '_mm512_shuffle_i32x4'
  ((__m512i)__builtin_ia32_shuf_i32x4((__v16si)(__m512i)(A), \
            ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
7 warnings and 20 errors generated.
Makefile:84: recipe for target 'ksw2_extd2_avx.o' failed
make: *** [ksw2_extd2_avx.o] Error 1
```